### PR TITLE
検索時に大文字小文字を区別しないように修正

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -132,7 +132,7 @@ export const getSortedItems = (items: any[], value: string, order: string) => {
 export const getFilteredItems = (items: Item[], keywords: string[]) => {
   return items.filter((item) =>
     Object.values(item).find((v: string) =>
-      v != null ? keywords.some((str) => v.includes(str)) : false
+      v != null ? keywords.some((str) => v.toLowerCase().includes(str.toLowerCase())) : false
     )
   )
 }


### PR DESCRIPTION
検索時の比較文字列を `.toLowerCase()` で小文字に揃えることで、大文字小文字の区別をしないようにしました。